### PR TITLE
add gcp filestore volume mount

### DIFF
--- a/nfs/gcp-filestore.yaml
+++ b/nfs/gcp-filestore.yaml
@@ -9,5 +9,5 @@ spec:
   - ReadWriteMany
   nfs:
     path: /vol1
-    server: 10.241.179.194
+    server: nfs.topse.private
 

--- a/nfs/gcp-filestore.yaml
+++ b/nfs/gcp-filestore.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: fileserver
+spec:
+  capacity:
+    storage: 1G
+  accessModes:
+  - ReadWriteMany
+  nfs:
+    path: /vol1
+    server: 10.241.179.194
+

--- a/nfs/persistent-volume-claim.yaml
+++ b/nfs/persistent-volume-claim.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: fileserver-claim
+spec:
+  accessModes:
+  - ReadWriteMany
+  storageClassName: ""
+  volumeName: fileserver
+  resources:
+    requests:
+      storage: 100M
+

--- a/nfs/wordpress-with-nfs-01.yaml
+++ b/nfs/wordpress-with-nfs-01.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: filestore-test-pod-01
+  labels:
+    app: wordpress-with-nfs
+spec:
+  containers:
+    - image: wordpress:4.8-apache
+      name: wordpress-with-nfs
+      env:
+        - name: WORDPRESS_DB_HOST
+          value: mysql.topse.private:3306
+        - name: WORDPRESS_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql
+              key: password
+      ports:
+        - containerPort: 80
+      volumeMounts:
+        - mountPath: /data
+          name: mypvc
+  volumes:
+    - name: mypvc
+      persistentVolumeClaim:
+        claimName: fileserver-claim
+        readOnly: false
+

--- a/nfs/wordpress-with-nfs-02.yaml
+++ b/nfs/wordpress-with-nfs-02.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: filestore-test-pod-02
+  labels:
+    app: wordpress-with-nfs
+spec:
+  containers:
+    - image: wordpress:4.8-apache
+      name: wordpress-with-nfs
+      env:
+        - name: WORDPRESS_DB_HOST
+          value: mysql.topse.private:3306
+        - name: WORDPRESS_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql
+              key: password
+      ports:
+        - containerPort: 80
+      volumeMounts:
+        - mountPath: /data
+          name: mypvc
+  volumes:
+    - name: mypvc
+      persistentVolumeClaim:
+        claimName: fileserver-claim
+        readOnly: false
+


### PR DESCRIPTION
異なるPodでNFS mountしたFSに追加したファイルが別Podで参照可能であることを確認しました。
```
rivvil1215@cloudshell:~/k8s-wordpress-mysql/nfs (topse-nagaku)$  gcloud container clusters get-credentials topse-cluster --region us-west1 --project topse-nagaku  && kubectl exec filestore-test-pod-01 -c wordpress-with-nfs -- ls /data
Fetching cluster endpoint and auth data.
kubeconfig entry generated for topse-cluster.
aaa.txt
lost+found
test.txt
rivvil1215@cloudshell:~/k8s-wordpress-mysql/nfs (topse-nagaku)$  gcloud container clusters get-credentials topse-cluster --region us-west1 --project topse-nagaku  && kubectl exec filestore-test-pod-02 -c wordpress-with-nfs -- ls /data
Fetching cluster endpoint and auth data.
kubeconfig entry generated for topse-cluster.
aaa.txt
lost+found
test.txt
```